### PR TITLE
ネットワークエラーのハンドリング機能の実装。

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import ReactDOM from 'react-dom/client';
 import reportWebVitals from './reportWebVitals';
 import EccubeSessionContainer from "./views/containers/share/EccubeSessionManager";
 import EccubeErrorCatcherContainer from "./views/containers/share/EccubeErrorCatcherContainer";
+import EccubeOfflineMode from "./views/containers/share/EccubeOfflineMode";
 
 /***
  * /////////////////////////////////////
@@ -61,7 +62,9 @@ root.render(
             <BrowserRouter>
                 <EccubeErrorCatcherContainer>
                     <EccubeSessionContainer>
-                        <App/>
+                        <EccubeOfflineMode>
+                            <App/>
+                        </EccubeOfflineMode>
                     </EccubeSessionContainer>
                 </EccubeErrorCatcherContainer>
             </BrowserRouter>

--- a/src/state/ducks/shared/site_health/actions.ts
+++ b/src/state/ducks/shared/site_health/actions.ts
@@ -10,11 +10,59 @@ export function raise404Error(payload) {
     }
 }
 
+// ==================================================
+// エベント履歴
+// ==================================================
+export function addToSiteHistory(event) {
+    return {
+        type: types.SITE_HEALTH_SITE_HISTORY_ADD,
+        payload: {
+            event: event
+        }
+    }
+}
+
+export function addRequestOnlyToSiteHistory(event) {
+    return {
+        type: types.SITE_HEALTH_REQUEST_ONLY_SITE_HISTORY_ADD,
+        payload: {
+            event: event
+        }
+    }
+}
+
+// ==================================================
+// オフラインモード
+// ==================================================
+
+export function turnOffline(event) {
+    return {
+        type: types.SITE_HEALTH_TURN_OFFLINE,
+        payload: {
+            is_offline: true,
+            event: event
+        }
+    }
+}
+
+export function turnOnline() {
+    return {
+        type: types.SITE_HEALTH_TURN_ONLINE,
+        payload: {
+            is_offline: false
+        }
+    }
+}
 
 
 
 const actions = {
-    raise404Error
+    raise404Error,
+    addToSiteHistory,
+    addRequestOnlyToSiteHistory,
+    
+    turnOffline,
+    turnOnline
 };
 
 export default actions;

--- a/src/state/ducks/shared/site_health/index.ts
+++ b/src/state/ducks/shared/site_health/index.ts
@@ -11,7 +11,7 @@
 import * as watchersSagas from './watchersSagas';
 
 export const siteHealthSagaWatchers = Object.values(watchersSagas);
-// export {default as siteHealthSelectors} from "./selectors";
+export {default as siteHealthSelectors} from "./selectors";
 export {default as siteHealthOperations} from "./operations";
 export {default as siteHealthTypes} from "./types";
 // export {default as siteHealthForms} from "./forms"

--- a/src/state/ducks/shared/site_health/operations.ts
+++ b/src/state/ducks/shared/site_health/operations.ts
@@ -8,10 +8,12 @@
  * 例: https://github.com/alexnm/re-ducks#operations (英語)
  * ////////////////////////////////////////////////////////
  */
+import actions from "./actions";
 
+const turnOnline = actions.turnOnline
 
 const operations = {
-    
+    turnOnline
 }
 
 export default operations;

--- a/src/state/ducks/shared/site_health/reducers.ts
+++ b/src/state/ducks/shared/site_health/reducers.ts
@@ -15,17 +15,42 @@ import types from "./types";
 
 export const siteHealthState = {
     is_404: false,
-    global_error: {}
+    global_error: {},
+    event_history: [],
+    request_only_event_history: [],
+    is_offline: false,
+    retry_event: {}
 }
 
 export default function siteHealthStateReducer(state = siteHealthState, action) {
-    
+
     switch (action.type) {
         case types.SITE_HEALTH_404_ERROR:
             return {
                 ...state,
                 is_404: state.is_404 = action.payload.is_404,
                 global_error: state.global_error = action.payload.global_error
+            }
+        case types.SITE_HEALTH_SITE_HISTORY_ADD:
+            return {
+                ...state,
+                event_history: state.event_history.concat([action.payload.event])
+            }
+        case types.SITE_HEALTH_REQUEST_ONLY_SITE_HISTORY_ADD:
+            return {
+                ...state,
+                request_only_event_history: state.request_only_event_history.concat([action.payload.event])
+            }
+        case types.SITE_HEALTH_TURN_OFFLINE:
+            return {
+                ...state,
+                is_offline: state.is_offline = action.payload.is_offline,
+                retry_event: state.retry_event = action.payload.event
+            }
+        case types.SITE_HEALTH_TURN_ONLINE:
+            return {
+                ...state,
+                is_offline: state.is_offline = action.payload.is_offline
             }
         default:
             return state;

--- a/src/state/ducks/shared/site_health/sagas.ts
+++ b/src/state/ducks/shared/site_health/sagas.ts
@@ -6,3 +6,13 @@
  * すべてのSAGAミドルウェアは、<i>watchersSagas.js</i>から呼び出されます。
  * ////////////////
  */
+
+import {put, select} from "redux-saga/effects";
+import actions from "./actions";
+import { siteHealthSelectors } from ".";
+
+export function* turnOnline(data) {
+    const lastRequestEvent = yield select(siteHealthSelectors.getFailedEvent);
+    // @TODO: 処理順番を検討する
+    yield put(lastRequestEvent);
+}

--- a/src/state/ducks/shared/site_health/selectors.ts
+++ b/src/state/ducks/shared/site_health/selectors.ts
@@ -10,19 +10,12 @@ import types from "./types";
  */
 
 function getLastSimilarEvent(state, event_name: string): string {
-    console.log(state);
-    console.log(state.siteHealth);
-    console.log(state.siteHealth.request_only_event_history);
     return state.siteHealth.request_only_event_history.filter((event) => {
-        console.log(event_name)
-        console.log(event.type);
-        console.log(event_name.includes(event.type));
         return event_name.includes(event.type);
     }).slice(-1)[0];
 }
 
 function getFailedEvent(state) {
-    console.log("DL: ", state.siteHealth)
     return state.siteHealth.retry_event;
 }
 

--- a/src/state/ducks/shared/site_health/selectors.ts
+++ b/src/state/ducks/shared/site_health/selectors.ts
@@ -8,3 +8,27 @@ import types from "./types";
  * リデューサーの生データをフィルタリングして、ビューにきれいな結果を提供するために使用されます。
  * ///////////////////////////////////////
  */
+
+function getLastSimilarEvent(state, event_name: string): string {
+    console.log(state);
+    console.log(state.siteHealth);
+    console.log(state.siteHealth.request_only_event_history);
+    return state.siteHealth.request_only_event_history.filter((event) => {
+        console.log(event_name)
+        console.log(event.type);
+        console.log(event_name.includes(event.type));
+        return event_name.includes(event.type);
+    }).slice(-1)[0];
+}
+
+function getFailedEvent(state) {
+    console.log("DL: ", state.siteHealth)
+    return state.siteHealth.retry_event;
+}
+
+const selectors = {
+    getLastSimilarEvent,
+    getFailedEvent
+}
+
+export default selectors;

--- a/src/state/ducks/shared/site_health/types.ts
+++ b/src/state/ducks/shared/site_health/types.ts
@@ -9,10 +9,18 @@
  * //////////////////////////////////////////////////////////////
  */
 export const SITE_HEALTH_404_ERROR: string = "SITE_HEALTH_404_ERROR";
-
+export const SITE_HEALTH_SITE_HISTORY_ADD: string = "SITE_HEALTH_SITE_HISTORY_ADD";
+export const SITE_HEALTH_REQUEST_ONLY_SITE_HISTORY_ADD: string = "SITE_HEALTH_REQUEST_ONLY_SITE_HISTORY_ADD";
+export const SITE_HEALTH_TURN_OFFLINE: string = "SITE_HEALTH_TURN_OFFLINE";
+export const SITE_HEALTH_TURN_ONLINE: string = "SITE_HEALTH_TURN_ONLINE";
 
 const types = {
-    SITE_HEALTH_404_ERROR
+    SITE_HEALTH_404_ERROR,
+    SITE_HEALTH_SITE_HISTORY_ADD,
+    SITE_HEALTH_REQUEST_ONLY_SITE_HISTORY_ADD,
+    
+    SITE_HEALTH_TURN_OFFLINE,
+    SITE_HEALTH_TURN_ONLINE
 }
 
 export default types;

--- a/src/state/ducks/shared/site_health/watchersSagas.ts
+++ b/src/state/ducks/shared/site_health/watchersSagas.ts
@@ -1,5 +1,6 @@
 import {takeLeading} from "redux-saga/effects";
 import types from "./types";
+import { turnOnline } from "./sagas";
 
 /**
  * //////////////////////////////////////////
@@ -10,5 +11,5 @@ import types from "./types";
  * ////////////////////////////////////////////
  */
 export function* fetchRequests() {
-    
+    yield takeLeading(types.SITE_HEALTH_TURN_ONLINE, turnOnline);
 }

--- a/src/state/middleware/global/EccubeReduxEventHistory.ts
+++ b/src/state/middleware/global/EccubeReduxEventHistory.ts
@@ -1,0 +1,16 @@
+import actions from "../../ducks/shared/site_health/actions";
+
+export default function eccubeReduxEventHistory(storeAPI) {
+    return function wrapDispatch(next) {
+        return function handleAction(action) {
+            if (action.type.includes('SITE_HEALTH') === false) {
+                //@TODO: 未来にECCUBEクローム拡張機能のために、全エベントを記録する。今は、REQUESTのみを記録する。
+                //storeAPI.dispatch(actions.addToSiteHistory(action))
+                if (action.type.endsWith('REQUEST')) {
+                    storeAPI.dispatch(actions.addRequestOnlyToSiteHistory(action))
+                }
+            }
+            return next(action)
+        }
+    }
+}

--- a/src/state/middleware/global/ErrorOrganizationMiddleware.ts
+++ b/src/state/middleware/global/ErrorOrganizationMiddleware.ts
@@ -1,39 +1,61 @@
-import actions from "../../ducks/shared/site_health/actions";
+import actions, {turnOffline} from "../../ducks/shared/site_health/actions";
+import {select} from "redux-saga/effects";
+import {siteHealthSelectors} from "../../ducks/shared/site_health";
+
 export default function ErrorOrganizationMiddleware(storeAPI) {
     return function wrapDispatch(next) {
         return function handleAction(action) {
-            if (action.type.includes('REQUEST_FAILURE') && action.payload?.errorData?.graphQLErrors) {
+            if (action.type.includes('REQUEST_FAILURE')) {
                 console.log(action);
-                // エラー処理                
-                action.payload.errorData = {
-                    simple: {
-                        ...action.payload.errorData.graphQLErrors.map((error) => {
-                            /** @todo: "FormValidation"を環境変数にする */
-                            const fieldsObj = (error.extensions.category === "FormValidation" ? error.extensions.errorDetails.reduce((errorDetail, item) => {
-                                return Object.assign(errorDetail, { [item.field]: item.message });
-                            }) : null);
-                                return {
-                                    message: error.message,
-                                    level: error.extensions.level,
-                                    category: error.extensions.category,
-                                    type: error.extensions?.type,
-                                    fields: fieldsObj,
-                                    generalErrorDetail: (error.extensions.category !== "FormValidation" ? error.extensions.errorDetails : null)
-                                }
-                            }
-                        ),
-                    },
-                    developer: {
-                        ...action.payload.errorData
+                // ネットワークエラーの場合 //
+                if (action.payload.errorData.networkError && action.payload.errorData.message === "Failed to fetch") {
+                    // ネットワークエラー
+                    const state = storeAPI.getState();
+                    const eventName = action.type;
+                    // 直近の同じイベントを取得
+                    const result = siteHealthSelectors.getLastSimilarEvent(state, eventName);
+                    if (result) {
+                        // オフラインイベントを発行
+                        storeAPI.dispatch(turnOffline(result));
+                    } else {
+                        // エベントが見つからない場合は、単純なネットワークエラーを発行
+                        alert('ネットワークエラーが発生しました。');
                     }
                 }
-                console.log(action.payload.errorData);
-                /** @todo: "ItemNotFound"を環境変数にする */
-                if(action.payload.errorData?.simple[0]?.type === "ItemNotFound") {
-                    // 404 アクションを発行
-                    console.log("404エラー");
-                    storeAPI.dispatch(actions.raise404Error(action.payload.errorData?.simple[0]))
+                // GraphQLエラーの場合 //
+                else if (action.payload?.errorData?.graphQLErrors) {
+                    // エラー処理                
+                    action.payload.errorData = {
+                        simple: {
+                            ...action.payload.errorData.graphQLErrors.map((error) => {
+                                    /** @todo: "FormValidation"を環境変数にする */
+                                    const fieldsObj = (error.extensions.category === "FormValidation" ? error.extensions.errorDetails.reduce((errorDetail, item) => {
+                                        return Object.assign(errorDetail, {[item.field]: item.message});
+                                    }) : null);
+                                    return {
+                                        message: error.message,
+                                        level: error.extensions.level,
+                                        category: error.extensions.category,
+                                        type: error.extensions?.type,
+                                        fields: fieldsObj,
+                                        generalErrorDetail: (error.extensions.category !== "FormValidation" ? error.extensions.errorDetails : null)
+                                    }
+                                }
+                            ),
+                        },
+                        developer: {
+                            ...action.payload.errorData
+                        }
+                    }
+                    // 404エラーの場合 //
+                    /** @todo: "ItemNotFound"を環境変数にする */
+                    if (action.payload.errorData?.simple[0]?.type === "ItemNotFound") {
+                        // 404 アクションを発行
+                        console.log("404エラー");
+                        storeAPI.dispatch(actions.raise404Error(action.payload.errorData?.simple[0]))
+                    }
                 }
+
             }
             return next(action)
         }

--- a/src/state/middleware/global/ErrorOrganizationMiddleware.ts
+++ b/src/state/middleware/global/ErrorOrganizationMiddleware.ts
@@ -6,7 +6,6 @@ export default function ErrorOrganizationMiddleware(storeAPI) {
     return function wrapDispatch(next) {
         return function handleAction(action) {
             if (action.type.includes('REQUEST_FAILURE')) {
-                console.log(action);
                 // ネットワークエラーの場合 //
                 if (action.payload.errorData.networkError && action.payload.errorData.message === "Failed to fetch") {
                     // ネットワークエラー

--- a/src/state/middleware/global/index.ts
+++ b/src/state/middleware/global/index.ts
@@ -1,7 +1,9 @@
+import eccubeReduxEventHistory from "./EccubeReduxEventHistory";
 import ErrorOrganizationMiddleware from "./ErrorOrganizationMiddleware";
 
-const EccubeMiddlewareHub = {
+const EccubeMiddlewareHub = [
+    eccubeReduxEventHistory,
     ErrorOrganizationMiddleware
-}
+]
 
 export default EccubeMiddlewareHub

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -27,7 +27,9 @@ export default function configureStore(REDUX_INITIAL_DATA: any | undefined) {
     middlewares.push(sagaMiddleware);
     
     // ECCUBE自作ミドルウェアを追加
-    middlewares.push(MiddlewareHub.ErrorOrganizationMiddleware);
+    for (const middleware of MiddlewareHub) {
+        middlewares.push(middleware);
+    }
     
     const rootReducer = combineReducers(reducers);
 

--- a/src/views/containers/share/EccubeOfflineMode.tsx
+++ b/src/views/containers/share/EccubeOfflineMode.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import {compose} from "redux";
+import {connect} from "react-redux";
+import {withTranslation} from "react-i18next";
+import {Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Grid} from "@mui/material";
+import {siteHealthOperations} from "../../../state/ducks/shared/site_health";
+
+const mapStateToProps = state => {
+    return {
+        is_offline: state.siteHealth.is_offline as boolean
+    }
+}
+
+/**
+ * Reduxアクション（これもコンポーネントのパラメータに挿入されます。)
+ */
+const mapEventToProps = {
+    turnOnline: siteHealthOperations.turnOnline,
+}
+
+const _EccubeOfflineMode = ({
+                                t,
+                                is_offline,
+                                turnOnline,
+                                ...props
+                            }) => {
+    return (
+        <>
+            {props.children}
+            <Dialog
+                open={is_offline}
+            >
+                <DialogTitle id="alert-dialog-title">
+                    オフラインモード
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText id="alert-dialog-description">
+                        EC-サイトに接続できません。ネットワーク接続を確認してください。
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => turnOnline()} autoFocus>
+                        再接続
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </>
+    )
+}
+
+const EccubeOfflineMode = compose<any, any, any>(
+    connect(mapStateToProps, mapEventToProps),
+    withTranslation('common'))(_EccubeOfflineMode)
+
+export default EccubeOfflineMode;


### PR DESCRIPTION
## プルリクエスト概要

このプルリクエストでは、ネットワークエラーのハンドリング機能の実装を提案しています。

## 変更内容

このプルリクエストに含まれる変更内容は以下の通りです：

- ネットワークエラーが発生した場合の適切なオフラインダイログボックスの表示

- オフラインダイログボックスで再接続ボタンをクリックしたら、失敗した最新Reactエベントのリクエストを再送信する